### PR TITLE
Confirmation on delete chart and datasource / mdDialog upgrades

### DIFF
--- a/src/main/webapp/app.js
+++ b/src/main/webapp/app.js
@@ -1,4 +1,4 @@
-var app = angular.module("perfmonReportsApp", ['ngRoute','ngMaterial','ngMdIcons']);
+var app = angular.module("perfmonReportsApp", ['ngRoute','ngMaterial']);
 app.config(function($routeProvider, $mdThemingProvider) {
 	$mdThemingProvider.theme('default')
 	  .primaryPalette('grey', {

--- a/src/main/webapp/components/chart/chartController.js
+++ b/src/main/webapp/components/chart/chartController.js
@@ -216,7 +216,15 @@ app.controller('chartControl', function ($scope, $routeParams, $mdDialog, chartS
 	$scope.showChart = function() {
 		setTimeout(function(){
 			if (chartService.isChartLoading===true){
-				window.alert("The chart failed to render.  Connection to database may have been lost.");
+				$mdDialog.show(
+			      $mdDialog.alert()
+			        .parent(angular.element(document.querySelector('#popupContainer')))
+			        .clickOutsideToClose(true)
+			        .title('Chart Render Failure')
+			        .content('The chart failed to render. Connection to database may have been lost.')
+			        .ariaLabel('Chart Render Failure')
+			        .ok('OK')
+			    );
 			}
 		
 		}, 60000);
@@ -321,7 +329,15 @@ app.controller('chartControl', function ($scope, $routeParams, $mdDialog, chartS
 			}
 			chartService.isChartLoading = false;
 		}).catch(function onError(err) {
-			window.alert("Failed to save chart");
+			$mdDialog.show(
+		      $mdDialog.alert()
+		        .parent(angular.element(document.querySelector('#popupContainer')))
+		        .clickOutsideToClose(true)
+		        .title('Chart Save Failure')
+		        .content('The chart failed to save.')
+		        .ariaLabel('Chart Save Failure')
+		        .ok('OK')
+		    );
 			chartService.isChartLoading = false;
 		})
 	

--- a/src/main/webapp/components/chart/chartSeriesController.js
+++ b/src/main/webapp/components/chart/chartSeriesController.js
@@ -27,7 +27,15 @@ app.controller('chartSeriesControl', function ($scope, $routeParams, chartServic
 		
 		setTimeout(function(){
 			if (isEmptyOrNull($scope.systems)){
-				window.alert("Cannot connect to database / systems are null");
+				$mdDialog.show(
+			      $mdDialog.alert()
+			        .parent(angular.element(document.querySelector('#popupContainer')))
+			        .clickOutsideToClose(true)
+			        .title('Error')
+			        .content('Cannot connect to database / systems are null.')
+			        .ariaLabel('Database connection issue or systems are null')
+			        .ok('OK')
+			    );
 			}
 			
 		}, 5000);

--- a/src/main/webapp/components/home/home.jsp
+++ b/src/main/webapp/components/home/home.jsp
@@ -44,14 +44,14 @@
 					<tr ng-repeat="chart in charts"> 
 						<td> 
 							<div class="right">
-								<a title="Edit Chart" class="chartrowIconAnchor">
-									<ng-md-icon title="Edit Chart" class="edit-icon-dark" icon="mode_edit" size="25" ng-click="editChart(chart.id);openSideNav()"></ng-md-icon>
+								<a title="Edit Chart" class="chartrowIconAnchor" ng-click="editChart(chart.id);openSideNav()">
+									<i class="material-icons">mode edit</i>
 								</a>
-								<a title="Duplicate Chart" class="chartrowIconAnchor">
-									<ng-md-icon title="Duplicate Chart" class="duplicate-icon-dark" icon="content_copy" size="25" ng-click="copyChart(chart.id)"></ng-md-icon>
+								<a title="Duplicate Chart" class="chartrowIconAnchor" ng-click="copyChart(chart.id)">
+									<i class="material-icons">content_copy</i>
 								</a>
-								<a title="Delete Chart" class="chartrowIconAnchor">
-									<ng-md-icon title="Delete Chart" class="delete-icon-dark" icon="delete" size="25" ng-click="deleteChart(chart.id)"></ng-md-icon>
+								<a title="Delete Chart" class="chartrowIconAnchor" ng-click="deleteChart(chart.id)">
+									<i class="material-icons">delete</i>
 								</a>
 							</div>
 							<a class="chartrowLinkAnchor" href="#/chart/{{chart.id}}">{{ chart.chartName }}</a>
@@ -102,15 +102,11 @@
 					<td> 
 					
 						<div class="right">
-							<a title="Edit DataSource" class="chartrowIconAnchor">
-								<ng-md-icon title="Edit DataSource" class="edit-icon-dark" icon="mode_edit" size="25"  ng-click="editDataSource($mnv, ds.id, ds.name, ds.url)"></ng-md-icon>
+							<a title="Edit DataSource" class="md-icon-button chartrowIconAnchor" ng-click="editDataSource($mnv, ds.id, ds.name, ds.url)">
+								<i class="material-icons">mode edit</i>
 							</a>
-							<a title="Delete DataSource" class="chartrowIconAnchor">
-							<!-- 
-								<ng-md-icon title="Delete DataSource" class="delete-icon-dark" icon="delete" size="25" ng-click="showConfirmDelete($event)"></ng-md-icon> -->
-								<md-button class="md-icon-button" ng-click="showConfirmDelete($event)">
-									<ng-md-icon class="delete-icon-dark" icon="delete" size="25"></ng-md-icon>
-								</md-button>
+							<a title="Delete DataSource" class="chartrowIconAnchor" ng-click="deleteDataSource(ds.id)">
+								<i class="material-icons">delete</i>
 							</a>
 						</div>
 						<a class="datasourceRowText">{{ ds.name }}</a>

--- a/src/main/webapp/components/home/home.jsp
+++ b/src/main/webapp/components/home/home.jsp
@@ -106,7 +106,11 @@
 								<ng-md-icon title="Edit DataSource" class="edit-icon-dark" icon="mode_edit" size="25"  ng-click="editDataSource($mnv, ds.id, ds.name, ds.url)"></ng-md-icon>
 							</a>
 							<a title="Delete DataSource" class="chartrowIconAnchor">
-								<ng-md-icon title="Delete DataSource" class="delete-icon-dark" icon="delete" size="25" ng-click="showConfirmDelete($event)"></ng-md-icon>
+							<!-- 
+								<ng-md-icon title="Delete DataSource" class="delete-icon-dark" icon="delete" size="25" ng-click="showConfirmDelete($event)"></ng-md-icon> -->
+								<md-button class="md-icon-button" ng-click="showConfirmDelete($event)">
+									<ng-md-icon class="delete-icon-dark" icon="delete" size="25"></ng-md-icon>
+								</md-button>
 							</a>
 						</div>
 						<a class="datasourceRowText">{{ ds.name }}</a>

--- a/src/main/webapp/components/home/home.jsp
+++ b/src/main/webapp/components/home/home.jsp
@@ -106,7 +106,7 @@
 								<ng-md-icon title="Edit DataSource" class="edit-icon-dark" icon="mode_edit" size="25"  ng-click="editDataSource($mnv, ds.id, ds.name, ds.url)"></ng-md-icon>
 							</a>
 							<a title="Delete DataSource" class="chartrowIconAnchor">
-								<ng-md-icon title="Delete DataSource" class="delete-icon-dark" icon="delete" size="25" ng-click="deleteDataSource(ds.id)"></ng-md-icon>
+								<ng-md-icon title="Delete DataSource" class="delete-icon-dark" icon="delete" size="25" ng-click="showConfirmDelete($event)"></ng-md-icon>
 							</a>
 						</div>
 						<a class="datasourceRowText">{{ ds.name }}</a>

--- a/src/main/webapp/components/home/homeController.js
+++ b/src/main/webapp/components/home/homeController.js
@@ -14,7 +14,15 @@ app.controller('homeControl', function ($scope, $location, dataSourceService, ch
 		}
 		$scope.datasources = result.data;
 	}).catch(function onError(err) {
-		window.alert("Failed to load datasources " + err.message );
+		$mdDialog.show(
+	      $mdDialog.alert()
+	        .parent(angular.element(document.querySelector('#popupContainer')))
+	        .clickOutsideToClose(true)
+	        .title('Error')
+	        .content('Failed to load datasources ' + err.message)
+	        .ariaLabel('Database load failure')
+	        .ok('OK')
+	    );
 	})
 	
 	var publicChartFetchPromise = chartService.getPublicCharts();
@@ -29,7 +37,15 @@ app.controller('homeControl', function ($scope, $location, dataSourceService, ch
 		
 		$scope.publicCharts = publicCharts;
 	}).catch(function onError(err) {
-		window.alert("Failed to load public charts " + err.message );
+		$mdDialog.show(
+	      $mdDialog.alert()
+	        .parent(angular.element(document.querySelector('#popupContainer')))
+	        .clickOutsideToClose(true)
+	        .title('Error')
+	        .content('Failed to load public charts ' + err.message)
+	        .ariaLabel('Public charts load failure')
+	        .ok('OK')
+	    );
 	})
 		
 	var chartFetchPromise = chartService.getCharts();
@@ -44,7 +60,15 @@ app.controller('homeControl', function ($scope, $location, dataSourceService, ch
 		
 		$scope.charts = charts;
 	}).catch(function onError(err) {
-		window.alert("Failed to load charts " + err.message );
+		$mdDialog.show(
+	      $mdDialog.alert()
+	        .parent(angular.element(document.querySelector('#popupContainer')))
+	        .clickOutsideToClose(true)
+	        .title('Error')
+	        .content('Failed to load charts ' + err.message)
+	        .ariaLabel('Charts load failure')
+	        .ok('OK')
+	    );
 	})
 	
 	$scope.showChart = function() {
@@ -65,9 +89,18 @@ app.controller('homeControl', function ($scope, $location, dataSourceService, ch
 		deletePromise.then(function(result){
 			var successful = result.data;
 			if (!successful){
-				alert("Deleting chart with id: " + id + " was NOT successful.");
+				$mdDialog.show(
+			      $mdDialog.alert()
+			        .parent(angular.element(document.querySelector('#popupContainer')))
+			        .clickOutsideToClose(true)
+			        .title('Delete Chart Error')
+			        .content('Deleting chart with id: ' + id + ' was NOT successful.')
+			        .ariaLabel('Delete chart failure')
+			        .ok('OK')
+			    );
+			} else {
+				$location.path("/");
 			}
-			$location.path("/");
 		});
 	}
 	
@@ -75,9 +108,18 @@ app.controller('homeControl', function ($scope, $location, dataSourceService, ch
 		var copyPromise = chartService.copyChart(id);
 		copyPromise.then(function(result){
 			if(result.status != 204){
-				alert("Copying chart with id: " + id + " was NOT successful.");
+				$mdDialog.show(
+			      $mdDialog.alert()
+			        .parent(angular.element(document.querySelector('#popupContainer')))
+			        .clickOutsideToClose(true)
+			        .title('Duplicate Chart Error')
+			        .content('Duplicating chart with id: ' + id + ' was NOT successful.')
+			        .ariaLabel('Duplicate chart failure')
+			        .ok('OK')
+			    );
+			} else {
+				$location.path("/");
 			}
-			$location.path("/");
 		});
 	}
 	
@@ -92,10 +134,8 @@ app.controller('homeControl', function ($scope, $location, dataSourceService, ch
 	      .targetEvent(ev);
 
 	    $mdDialog.show(confirm).then(function() {
-	      alert("OK!");
 	      $scope.alert = 'You decided to get rid of your debt.';
 	    }, function() {
-	      alert("Cancel!");
 	      $scope.alert = 'You decided to keep your debt.';
 	    });
 	  };
@@ -106,9 +146,18 @@ app.controller('homeControl', function ($scope, $location, dataSourceService, ch
 	    deletePromise.then(function(result){
 	    	var successful = result.data;
 	    	if (!successful){
-	    		alert("This DataSource is being referenced by a chart. DataSource Id: " + id);
+	    		$mdDialog.show(
+			      $mdDialog.alert()
+			        .parent(angular.element(document.querySelector('#popupContainer')))
+			        .clickOutsideToClose(true)
+			        .title('Cannot Delete')
+			        .content('This DataSource is being referenced by a chart. DataSource id: ' + id)
+			        .ariaLabel('Cannot delete datasource')
+			        .ok('OK')
+			    );
+	    	} else {
+	    		$location.path("/");
 	    	}
-	    	$location.path("/");
 	    });
 	}
 	//Building the popup for datasource

--- a/src/main/webapp/components/home/homeController.js
+++ b/src/main/webapp/components/home/homeController.js
@@ -81,16 +81,35 @@ app.controller('homeControl', function ($scope, $location, dataSourceService, ch
 		});
 	}
 	
+	$scope.showConfirmDelete = function(ev) {
+	    // Appending dialog to document.body to cover sidenav in docs app
+	    var confirm = $mdDialog.confirm()
+	      .title('Would you like to delete your debt?')
+	      .content('All of the banks have agreed to forgive you your debts.')
+	      .ariaLabel('Lucky day')
+	      .ok('Please do it!')
+	      .cancel('Sounds like a scam')
+	      .targetEvent(ev);
+
+	    $mdDialog.show(confirm).then(function() {
+	      alert("OK!");
+	      $scope.alert = 'You decided to get rid of your debt.';
+	    }, function() {
+	      alert("Cancel!");
+	      $scope.alert = 'You decided to keep your debt.';
+	    });
+	  };
+	
 	//Ideally, we would want to show the names of the charts refrencing the datasource, but I'm not sure how to do that
 	$scope.deleteDataSource = function(id) {
-		var deletePromise = dataSourceService.deleteDataSource(id);
-		deletePromise.then(function(result){
-			var successful = result.data;
-			if (!successful){
-				alert("This DataSource is being referenced by a chart. DataSource Id: " + id);
-			}
-			$location.path("/");
-		});
+	    var deletePromise = dataSourceService.deleteDataSource(id);
+	    deletePromise.then(function(result){
+	    	var successful = result.data;
+	    	if (!successful){
+	    		alert("This DataSource is being referenced by a chart. DataSource Id: " + id);
+	    	}
+	    	$location.path("/");
+	    });
 	}
 	//Building the popup for datasource
 	$scope.showDataSources = function(ev) {

--- a/src/main/webapp/components/home/homeController.js
+++ b/src/main/webapp/components/home/homeController.js
@@ -85,23 +85,34 @@ app.controller('homeControl', function ($scope, $location, dataSourceService, ch
 	}
 	
 	$scope.deleteChart = function(id) {
-		var deletePromise = chartService.deleteChart(id);
-		deletePromise.then(function(result){
-			var successful = result.data;
-			if (!successful){
-				$mdDialog.show(
-			      $mdDialog.alert()
-			        .parent(angular.element(document.querySelector('#popupContainer')))
-			        .clickOutsideToClose(true)
-			        .title('Delete Chart Error')
-			        .content('Deleting chart with id: ' + id + ' was NOT successful.')
-			        .ariaLabel('Delete chart failure')
-			        .ok('OK')
-			    );
-			} else {
-				$location.path("/");
-			}
-		});
+		var confirm = $mdDialog.confirm()
+	      .title('Delete?')
+	      .content('Are you sure you want to delete this chart?')
+	      .ariaLabel('Chart deletion confirmation')
+	      .ok('OK')
+	      .cancel('Cancel');
+
+	    $mdDialog.show(confirm).then(function() { // user clicks OK
+	    	var deletePromise = chartService.deleteChart(id);
+			deletePromise.then(function(result){
+				var successful = result.data;
+				if (!successful){
+					$mdDialog.show(
+				      $mdDialog.alert()
+				        .parent(angular.element(document.querySelector('#popupContainer')))
+				        .clickOutsideToClose(true)
+				        .title('Delete Chart Error')
+				        .content('Deleting chart with id: ' + id + ' was NOT successful.')
+				        .ariaLabel('Delete chart failure')
+				        .ok('OK')
+				    );
+				} else {
+					$location.path("/");
+				}
+			});
+	    }, function() { // user clicks Cancel
+	      // do nothing
+	    });
 	}
 	
 	$scope.copyChart = function(id){
@@ -123,41 +134,34 @@ app.controller('homeControl', function ($scope, $location, dataSourceService, ch
 		});
 	}
 	
-	$scope.showConfirmDelete = function(ev) {
-	    // Appending dialog to document.body to cover sidenav in docs app
-	    var confirm = $mdDialog.confirm()
-	      .title('Would you like to delete your debt?')
-	      .content('All of the banks have agreed to forgive you your debts.')
-	      .ariaLabel('Lucky day')
-	      .ok('Please do it!')
-	      .cancel('Sounds like a scam')
-	      .targetEvent(ev);
-
-	    $mdDialog.show(confirm).then(function() {
-	      $scope.alert = 'You decided to get rid of your debt.';
-	    }, function() {
-	      $scope.alert = 'You decided to keep your debt.';
-	    });
-	  };
-	
-	//Ideally, we would want to show the names of the charts refrencing the datasource, but I'm not sure how to do that
 	$scope.deleteDataSource = function(id) {
-	    var deletePromise = dataSourceService.deleteDataSource(id);
-	    deletePromise.then(function(result){
-	    	var successful = result.data;
-	    	if (!successful){
-	    		$mdDialog.show(
-			      $mdDialog.alert()
-			        .parent(angular.element(document.querySelector('#popupContainer')))
-			        .clickOutsideToClose(true)
-			        .title('Cannot Delete')
-			        .content('This DataSource is being referenced by a chart. DataSource id: ' + id)
-			        .ariaLabel('Cannot delete datasource')
-			        .ok('OK')
-			    );
-	    	} else {
-	    		$location.path("/");
-	    	}
+		var confirm = $mdDialog.confirm()
+	      .title('Delete?')
+	      .content('Are you sure you want to delete this datasource?')
+	      .ariaLabel('Datasource deletion confirmation')
+	      .ok('OK')
+	      .cancel('Cancel');
+
+	    $mdDialog.show(confirm).then(function() { // user clicks OK
+	    	var deletePromise = dataSourceService.deleteDataSource(id);
+		    deletePromise.then(function(result){
+		    	var successful = result.data;
+		    	if (!successful){
+		    		$mdDialog.show(
+				      $mdDialog.alert()
+				        .parent(angular.element(document.querySelector('#popupContainer')))
+				        .clickOutsideToClose(true)
+				        .title('Cannot Delete')
+				        .content('This DataSource is being referenced by a chart. DataSource id: ' + id)
+				        .ariaLabel('Cannot delete datasource')
+				        .ok('OK')
+				    );
+		    	} else {
+		    		$location.path("/");
+		    	}
+		    });
+	    }, function() { // user clicks Cancel
+	      // do nothing
 	    });
 	}
 	//Building the popup for datasource

--- a/src/main/webapp/css/home.css
+++ b/src/main/webapp/css/home.css
@@ -45,36 +45,6 @@ a {
 a:hover, a:active {
     color: #000000; 
 }
-.home-icon-light {
-	fill: #FFFFFF;
-}
-.home-icon-light:hover {
-	fill: #E0E0E0;
-}
-.edit-icon-dark {
-	fill: #616161;
-}
-.edit-icon-dark:hover {
-	fill: #000000;
-}
-.duplicate-icon-dark {
-	fill: #616161;
-}
-.duplicate-icon-dark:hover {
-	fill: #000000;
-}
-.delete-icon-dark {
-	fill: #616161;
-}
-.delete-icon-dark:hover {
-	fill: #000000;
-}
-
-.md-button.md-icon-button {
-	padding: 0px 0px 0px 0px;
-	height: 25px;
-	width: 25px;
-}
 
 .chartrowIconAnchor {
 	display: inline-block;

--- a/src/main/webapp/css/home.css
+++ b/src/main/webapp/css/home.css
@@ -69,6 +69,13 @@ a:hover, a:active {
 .delete-icon-dark:hover {
 	fill: #000000;
 }
+
+.md-button.md-icon-button {
+	padding: 0px 0px 0px 0px;
+	height: 25px;
+	width: 25px;
+}
+
 .chartrowIconAnchor {
 	display: inline-block;
 	padding: 5px 5px 2px;

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -17,10 +17,12 @@
 	  <title>Perfmon4J Reports</title>
 	  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.js"></script>
 	  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-route.min.js"></script>
+	  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-messages.min.js"></script>
 	  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-aria.min.js"></script>
 	  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-animate.min.js"></script>
 	  <script src="https://cdn.rawgit.com/angular/bower-material/v0.9.7/angular-material.js"></script>
 	  <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-material-icons/0.4.0/angular-material-icons.min.js"></script>
+	  <script src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/t-114/assets-cache.js"></script>
 	  
 	  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
 	  <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.min.js"></script>
@@ -34,7 +36,6 @@
 	  <script src="components/chart/chartRenderController.js"></script>
 	  <script src="components/chart/chartDirective.js"></script>
 	  <script src="components/chart/chartController.js"></script>
-	  <script src="components/chart/chartRenderDirective.js"></script>
 	  <script src="components/chart/sideNavController.js"></script>
 	  <script src="components/chart/chartSeriesDirective.js"></script>
 	  <script src="components/chart/chartSeriesController.js"></script>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -9,6 +9,7 @@
 	  <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no" />
 	  <link rel="stylesheet" href="https://cdn.rawgit.com/angular/bower-material/v0.9.7/angular-material.css">
 	  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.min.css"> 
+	  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 	  <link rel="stylesheet" href="css/home.css">
 	  <link rel="stylesheet" href="css/chart.css">
 	  <link rel="stylesheet" href="css/chartSeries.css">
@@ -21,7 +22,6 @@
 	  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-aria.min.js"></script>
 	  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-animate.min.js"></script>
 	  <script src="https://cdn.rawgit.com/angular/bower-material/v0.9.7/angular-material.js"></script>
-	  <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-material-icons/0.4.0/angular-material-icons.min.js"></script>
 	  <script src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/t-114/assets-cache.js"></script>
 	  
 	  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>


### PR DESCRIPTION
resolves [this story](https://github.com/FollettSchoolSolutions/perfmon4j-reports/issues/103).
list of things:    
* the icon set in the project has been switched from ng-md-icon to the default Google icon set
* all error _alert()_ popups in the project have been switched to _mdDialog.alert()_
* both delete icons for charts and datasources now have a confirmation dialog popup